### PR TITLE
fix: use 'master' tag for MDC in master branch

### DIFF
--- a/roles/provision-mdc-server-apb/defaults/main.yml
+++ b/roles/provision-mdc-server-apb/defaults/main.yml
@@ -1,6 +1,6 @@
 # MCS Values
 mobile_developer_console_image: "docker.io/aerogear/mobile-developer-console"
-mobile_developer_console_image_tag: "1.0.0"
+mobile_developer_console_image_tag: "master"
 mobile_developer_console_port: 4000
 mobile_developer_console_proxy_port: 4180
 mobile_developer_console_enable_build_tab: false


### PR DESCRIPTION
For some time, we've been testing latest mobile-developer-console-apb with MDC from December.
We need to target the latest version of the image in `master` branch https://hub.docker.com/r/aerogear/mobile-developer-console/tags